### PR TITLE
bug: typo in test definition

### DIFF
--- a/2. Reading Version Messages.ipynb
+++ b/2. Reading Version Messages.ipynb
@@ -837,7 +837,7 @@
     "    ipv4 = '10.10.10.10'\n",
     "    ipv4_mapped = b'\\x00'*10 + b'\\xff'*2 + ip_address(ipv4).packed\n",
     "    stream = BytesIO(ipv4_mapped)    \n",
-    "    assert read_ip(stream).ipv4_mapped.compressed == ipv4\n",
+    "    assert read_ip(stream).compressed == ipv4\n",
     "    \n",
     "ipytest.run_tests(doctest=True)\n",
     "ipytest.clean_tests(\"test_read_ip*\")"


### PR DESCRIPTION
resolves issue #1 
Running the test will throw AttributeError: 'IPv4Address' object has no attribute 'ipv4_mapped'